### PR TITLE
Add support to block selection mode in vim.

### DIFF
--- a/config/nvim/lua/statusline/init.lua
+++ b/config/nvim/lua/statusline/init.lua
@@ -15,7 +15,7 @@ gls.left[2] = {
     provider = function()
       -- auto change color according the vim mode
       local mode_color = {n = colors.red, i = colors.green,v=colors.blue,
-                          [''] = colors.blue,V=colors.blue,
+                          [''] = colors.blue,V=colors.blue,  [''] = colors.blue,
                           c = colors.magenta,no = colors.red,s = colors.orange,
                           S=colors.orange,[''] = colors.orange,
                           ic = colors.yellow,R = colors.violet,Rv = colors.violet,


### PR DESCRIPTION
Previous, when pressing `Ctrl+V`, the following error will occur:

```
.config/nvim/lua/statusline/init.lua:25: attempt to concatenate a nil value function: builtin#18 /Users/a0233027/.config/nvim/lua/statusline/init.lua:25: attempt to co...fig/n
vim/lua/statusline/init.lua:25: attempt to concatenate a nil value function: builtin#18 /Users/a0233027/.config/nvim/lua/statusline/init.lua:25: attempt to concatenate a nil value
E15: Invalid expression: luaeval('require("galaxyline").component_decorator')("ViMode")
```

This is due to that there is no color was set for `block selection mode` in vim.